### PR TITLE
fix(checkout): reduce server request count

### DIFF
--- a/assets/scripts/checkout.js
+++ b/assets/scripts/checkout.js
@@ -19,7 +19,16 @@ document.addEventListener('alpine:init', () => {
     redirecting: false,
 
     init() {
-      setInterval(() => this.updateStock(), 30000);
+      setInterval(() => {
+        if (!document.hidden) {
+          this.updateStock()
+        }
+      }, 30000);
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+          this.updateStock();
+        }
+      });
       this.updateStock();
     },
 


### PR DESCRIPTION
Right now, we're getting ~0.5 million requests per day. I didn't anticipate the submission form will be in the homepage, and every user who has tinytapeout.com open in one of their browser tabs hits the server once per 30 seconds. With this fix, we'll only monitor stock state while the tab is active.