### PR TITLE
[ES] siliwiz main page & introduction translation + minor fixes

### DIFF
--- a/content/digital_design/design_uart/_index.en.md
+++ b/content/digital_design/design_uart/_index.en.md
@@ -70,7 +70,7 @@ Each column of flip flops stores a single ASCII character. To modify a character
 
 To add characters, copy and paste a column. Connect the output of the new column (Q port of the upper-most D-flip flop) to the input of the stage to the left (bottom-left most multiplexer port). Remember to connect the multiplexer select signal and the clock to the new column as well.
 
-Lastly, delete the the output of the first column (Q port of the upper-most D-flip flop) and create a new connection to the to the input of the new stage you've added (bottom-left most multiplexer port).
+Lastly, delete the output of the first column (Q port of the upper-most D-flip flop) and create a new connection to the to the input of the new stage you've added (bottom-left most multiplexer port).
 
 **How to use**
 

--- a/content/digital_design/puzzle_padlock_seq/_index.en.md
+++ b/content/digital_design/puzzle_padlock_seq/_index.en.md
@@ -110,11 +110,11 @@ stateDiagram-v2
 
 Set all switches to 0 and press the push button. A "-" will appear on the seven segment display.
 
-When you're ready, turn on Switch 2 and press the push button to begin the challenge. The yellow LED will turn on, and the seven segment display will show "L" for locked".
+When you're ready, turn on Switch 2 and press the push button to begin the challenge. The yellow LED will turn on, and the seven segment display will show "L" for "locked".
 
 Next set a code using Switches 3 to 5. If you enter a correct code, you will see the colored LED progress from yellow --> magenta.
 
-If you succeeded, try to get to the next stages, lighting the white LED then finally the cyan! A "U" will appear for unlocked. 
+If you succeeded, try to get to the next stages, lighting the white LED then finally the cyan! A "U" will appear for "unlocked".
 
 If you fail to enter the correct code at any stage, you will return to the yellow LED.
 

--- a/content/digital_design/wokwi_lut_generator/_index.en.md
+++ b/content/digital_design/wokwi_lut_generator/_index.en.md
@@ -11,7 +11,7 @@ Thanks to community member **maehw** for writing this article.
 
 ## Truth tables
 
-You have already learned about combinational logic that can be described by using a truth tables, e.g. the [full adder](https://tinytapeout.com/digital_design/puzzle_adder/).
+You have already learned about combinational logic that can be described by using a truth table, e.g. the [full adder](https://tinytapeout.com/digital_design/puzzle_adder/).
 
 Let's now have a look at at a decoder which converts a binary coded decimal digit (0..9) to control a [7-segment display](https://docs.wokwi.com/parts/wokwi-7segment). The input range can be covered using four bits (0..15=2^4-1), i.e. four input signals. We specify that valid input values are in the range 0..9, other values will show a blank display.
 

--- a/content/faq/_index.en.md
+++ b/content/faq/_index.en.md
@@ -123,7 +123,7 @@ No, unused gates will be optimised out by the ASIC tools.
 Yes, you need to 
 
 * [re-run the github action](#i-updated-and-saved-my-wokwi-design-how-do-i-re-run-the-github-action-to-update-the-gds-files).
-* Tell us to use your latest version using the (Tiny Tapeout application](https://app.tinytapeout.com/).
+* Tell us to use your latest version using the [Tiny Tapeout application](https://app.tinytapeout.com/).
 
 ## Do I need to use Wokwi, or could I use an HDL?
 

--- a/content/hdl/testing/_index.md
+++ b/content/hdl/testing/_index.md
@@ -69,7 +69,7 @@ endmodule
 Replace both instances of `toplevel_module` with the actual name of your top level module. In the [case of the demo](https://github.com/TinyTapeout/tt05-verilog-demo/blob/main/src/tt_um_seven_segment_seconds.v), it's `tt_um_seven_segment_seconds`.
 
 It can help make things clearer if you have 'convenience wires' that basically rename the important inputs and outputs of your design. In the demo, we want to reference the
-seven segment display output pins, which are output on `ui_out[6:0]`. So we make a new wire and connect it to those outputs:
+seven segment display output pins, which are output on `uo_out[6:0]`. So we make a new wire and connect it to those outputs:
 
 ```verilog
     wire [6:0] segments = uo_out[6:0];
@@ -173,7 +173,7 @@ The simulations we've covered above are all **pre synthesis**. A simulator reads
 
 It's well worth running the same test on the **post synthesis** netlist. 
 This post synthesis netlist is called a Gate Level netlist, because it includes all the actual standard cells (gates) used by your design. 
-Gate Level testing can expose some bugs or issues that weren't by exposed by HDL simulation.
+Gate Level testing can expose some bugs or issues that weren't exposed by HDL simulation.
 
 This Gate Level netlist snippet just shows 2 of the ~240 standard cells used to create the [tt05-verilog-demo](https://github.com/TinyTapeout/tt05-verilog-demo). You can have a look at
 yours by downloading the GDS.zip from the actions page of your design and then looking at the file: `runs/wokwi/results/final/verilog/gl/<your design name>.v`

--- a/content/siliwiz/_index.es.md
+++ b/content/siliwiz/_index.es.md
@@ -1,0 +1,8 @@
+---
+title: "¿Cómo funcionan los semiconductores?"
+weight: 70
+---
+
+[![](../../siliwiz/images/image60.png?width=40pc)](https://app.siliwiz.com)
+
+{{< children description="true" >}}

--- a/content/siliwiz/introduction/_index.es.md
+++ b/content/siliwiz/introduction/_index.es.md
@@ -1,0 +1,31 @@
+---
+title: Introducción a SiliWiz
+description: "Cómo SiliWiz te ayuda a comprender cómo funcionan los semiconductores y su fabricación"
+weight: 10
+---
+
+![](../../../siliwiz/images/image60.png?width=30pc)
+
+SiliWiz te ayudará a tener un entendimiento básico de cómo funcionan y son fabricados los semiconductores a nivel fundamental. Los semiconductores son la tecnología más importante del siglo 21, pero solo una pequeña fracción de la población sabe cómo funcionan o cómo son diseñados y manufacturados.
+
+Completar y entender todas las lecciones tomará alrededor de 3 horas.
+
+### Audiencia
+
+* Gente curiosa que probablemente tenga más de 14 años
+* Escuelas secundarias, universidades
+* Gente que quiera entender mejor cómo funciona la microelectrónica y cómo se hace.
+
+### Metas
+
+* Dibujar tu propia compuerta lógica y entender cómo esa compuerta puede ser manufacturada en una [fundición](https://www.zerotoasiccourse.com/terminology/foundry/).
+* Aprender cómo la compuerta es construida a partir de los elementos fundamentales que conforman los circuitos usados en un diseño de chip.
+* Entender cómo los dibujos se utilizan para manufacturar el chip.
+* Tener en cuenta algunas de las limitaciones y simplificaciones de SiliWiz
+
+### ¡Apoya el desarrollo de SiliWiz!
+
+* Diseña y encarga tu propio chip con [TinyTapeout](https://tinytapeout.com/)
+* Comparte y postea en redes sociales con el hashtag [#SiliWiz](https://twitter.com/search?q%3D%2523siliwiz)
+* [Suscríbete a la lista de correo](https://zerotoasiccourse.com/newsletter)
+* [Inscríbete en el curso más avanzado y altamente aclamado de Matt, "Zero to ASIC"](https://zerotoasiccourse.com) (sitio en inglés)


### PR DESCRIPTION
- **first commit:** siliwiz main page + introduction page are now in spanish.
- **second commit:** small errors in english pages fixed:
    - _`faq` line 126:_ bad syntax caused broken link.
    - _`digital_design/design_uart` line 73:_ double "the".
    - _`digital_design/puzzle_padlock` lines 113 & 117:_ missing quotations (just for consistency's sake).
    - _`digital_design/wokwi_lut_gen` line 14:_ "by using a truth table<s>s</s>" -> "by using a truth table"
    - _`hdl/testing` line 72:_ "ui_out" corrected to "uo_out".
    - _`hdl/testing` line 176:_ double "by".