### PR TITLE
[ES] spanish translation of 'tech specs' pages

### DIFF
--- a/content/specs/_index.es.md
+++ b/content/specs/_index.es.md
@@ -1,0 +1,7 @@
+---
+title: 'Especificaciones técnicas'
+description: 'Especificaciones técnicas de los Chips y PCBs de Tiny Tapeout'
+weight: 85
+---
+
+{{< children description="true" >}}

--- a/content/specs/clock/_index.es.md
+++ b/content/specs/clock/_index.es.md
@@ -1,0 +1,27 @@
+---
+title: 'Reloj'
+description: 'Generación de reloj y limitaciones'
+weight: 10
+---
+
+La información en este documento aplica para Tiny Tapeout 04 en adelante.
+
+Tiny Tapeout incluye una señal de reloj de entrada (`clk`), suministrada externamente a través del pin `mprj_io[6]` del chip Caravel (pin número 37 en el chip QFN-64).
+
+![QFN-64 chip clk pin](/../../specs/clock/images/pinout_clk.svg)
+
+## Limitaciones
+
+Internamente, tanto el pin `rst_n` como el pin `clk` son manejados como cualquier otro pin de entrada. Se espera una latencia (retraso de inserción) de hasta 10 nanosegundos entre el pad de I/O (entrada/salida) del chip y el reloj de tu proyecto.
+
+El chip Caravel utiliza el macro [sky130_ef_io_gpiov2_pad](https://skywater-pdk.readthedocs.io/en/main/contents/libraries/sky130_fd_io/docs/user_guide.html#sky130-fd-io-gpiov2-additional-features) para los pads de I/O. La documentación especifica una frecuencia de entrada máxima de 66 MHz. Por ende, pensamos que la frecuencia máxima de reloj que podrás usar en tus diseños es de 66 MHz.
+
+## Generación de reloj
+
+La placa del Demo de Tiny Tapeout puede generar la señal de reloj para tus diseños. El reloj es generado por el microcontrolador integrado RP2040 ([código fuente del firmware aquí](https://github.com/TinyTapeout/tt-rp2040-firmware/blob/main/src/clkgen.c)).
+
+El RP2040 puede generar una amplia gama de frecuencias, incluyendo 50 MHz, 48 MHz (útil para USB), 40 MHz, 25.179 MHz (útil para VGA), 10 MHz, 1 MHz. Si necesitas una señal de reloj muy lenta, como 1 Hz, esto se puede lograr con un programa sencillo de CircuitPython.
+
+Puedes ver la lista completa de frecuencias verificadas en el [README del firmware](https://github.com/TinyTapeout/tt-rp2040-firmware#clock-configurations). Si necesitas una frecuencia que no aparece en la lista, no dudes en [abrir una propuesta](https://github.com/TinyTapeout/tt-rp2040-firmware/issues/new) y consideraremos agregarla a la lista.
+
+{{< figure src="/../../specs/clock/images/clk_25_179.png" title="Señal de reloj de 25.179 MHz generada por el chip RP2040" >}}

--- a/content/specs/pcb/_index.es.md
+++ b/content/specs/pcb/_index.es.md
@@ -1,0 +1,45 @@
+---
+title: 'PCB'
+description: 'PCBs'
+weight: 15
+---
+
+{{< figure src="/../../specs/pcb/images/tt02_board_top.jpeg" title="PCB de TT01, 02 & 03" >}}
+
+## Placa montadora
+
+Archivos PCB: https://github.com/TinyTapeout/caravel-breakout-pcb
+
+Los chips son montados en una placa portadora. Hay dos versiones, una para paquetes QFN y otra para paquetes WLCSP.
+Se espera que todos los chips TT sean en QFN.
+
+La placa portadora ayuda a:
+
+* acceder a todas las señales del chip
+* construir tu propia placa madre sin tener que soldar QFN o WLCSP
+
+## Placa demo para TT01, 02 & 03
+
+Archivos PCB: https://github.com/TinyTapeout/tt123-demo-pcb
+
+La placa de demostración provee facilidades para:
+
+* seleccionar el diseño activo mediante DIP switches
+* generar señales de reloj y reset de un único ciclo
+* conectar componentes externas mediante headers o Pmods (módulos periféricos)
+* ver las 8 salidas en el display de 7 segmentos
+* controlar las 8 entradas con DIP switches
+
+## Placa demo para TT04 en adelante
+
+Trabajo en curso: https://github.com/TinyTapeout/tt-demo-pcb
+
+La placa de demostración para el TT04 en adelante incluirá un chip RP2040 para:
+
+* seleccionar el diseño activo
+* generar la [señal de reloj](../clock/) para tus diseños, hasta 50 MHz
+* proveer [emulación de SPI RAM](https://github.com/MichaelBell/spi-ram-emu), hasta 512 KBit
+
+## Desarrollo de placa
+
+¡El desarrollo de la placa está patrocinado por [Aisler](https://aisler.net/)!

--- a/content/specs/pcb/_index.md
+++ b/content/specs/pcb/_index.md
@@ -22,7 +22,7 @@ The carrier board makes it easy to:
 
 PCB files: https://github.com/TinyTapeout/tt123-demo-pcb
 
-The demo board easy ways to:
+The demo board provides easy ways to:
 
 * select the active design with dip switches
 * single cycle clock and reset

--- a/content/specs/pinouts/_index.es.md
+++ b/content/specs/pinouts/_index.es.md
@@ -1,0 +1,126 @@
+---
+title: 'Distribución de pines'
+description: 'Pinouts recomendados para varios protocolos y módulos periféricos'
+weight: 20
+---
+
+Para hacer más fácil la puesta en marcha y la reutilización de placas, TT recomienda utilizar distribuciones de pines *(pinouts)* comunes donde sea posible. Si tu diseño usa el mismo pinout que los otros diseños, será mucho más sencillo conectar hardware externo o crear placas propias que se puedan implementar en aquellos diseños.
+
+El uso de pinouts comunes no es obligatorio, pero sí es recomendado ya que TT es un shuttle comunitario. No dudes en desviarte de las recomendaciones si lo estimas necesario para tus diseños. Si utilizas un protocolo o Pmod que no se encuentra listado aquí, por favor haz una propuesta en el servidor de Discord.
+
+## Periféricos comunes
+
+**UART a USB**
+
+Si quieres interactuar con tu diseño a través de consola serial, puedes hacerlo a través del RP2040 integrado en la placa demo. Así, puedes conectar la placa demo mediante USB y enviar/recibir datos desde tu chip.
+
+ui_in[3]  - RX\
+uo_out[4] - TX
+
+**Salida VGA**
+
+![Tiny VGA](/../../specs/pinouts/images/tiny_vga.jpg)
+
+Para salida VGA se recomienda usar el pinout de [Tiny VGA](https://github.com/mole99/tiny-vga). La placa es de código abierto y solo utiliza un Pmod para que puedas usar de todos modos el Pmod bidireccional, u otra cosa.
+
+Incluso si piensas en diseñar tu propia placa montadora, tiene sentido utilizar el pinout de Tiny VGA para que otros puedan probar tu diseño.
+
+Nota: Es posible que Tiny VGA pueda ser comprado en Tiny Tapeout más adelante. Por ahora existe la posibilidad de construir la placa por tí mismo.
+
+Pinout:
+
+uo_out[0] - R1\
+uo_out[1] - G1\
+uo_out[2] - B1\
+uo_out[3] - vsync\
+uo_out[4] - R0\
+uo_out[5] - G0\
+uo_out[6] - B0\
+uo_out[7] - hsync
+
+**RAM SPI**
+
+El microcontrolador RP2040 de la placa demo puede configurarse para proveer RAM al chip a través de SPI gracias a [spi-ram-emu](https://github.com/MichaelBell/spi-ram-emu/).
+
+Pinout:
+
+uio[0] - GPIO21 - CS\
+uio[1] - GPIO22 - MOSI\
+uio[2] - GPIO23 - MISO\
+uio[3] - GPIO24 - SCK
+
+Esto se asigna al pinout SPI estándar para Pmods, lo que quiere decir que un Pmod PSRAM podría ser usado como reemplazo directo.
+
+## Protocolos comunes (SPI, I2C y UART)
+
+Si quieres implementar protocolos que no se dirigen necesariamente a algún Pmod, te sugerimos usar el pinout para I2C, SPI y UART de las [especificaciones Pmod](https://digilent.com/reference/_media/reference/pmod/pmod-interface-specification-1_2_0.pdf)
+
+**SPI**
+
+El protocolo SPI utiliza CS, MOSI, MISO y SCK, y por ende solo requiere una fila de pins del conector Pmod, preferiblemente la fila superior. Ya que el estándar SPI debe enviar y recibir, se utiliza el Pmod bidireccional.
+
+Fila superior:
+
+uio[0] - CS\
+uio[1] - MOSI\
+uio[2] - MISO\
+uio[3] - SCK
+
+Fila inferior:
+
+uio[4] - CS\
+uio[5] - MOSI\
+uio[6] - MISO\
+uio[7] - SCK
+
+Si tu diseño solo recibe datos o solo transmite datos mediante SPI, puedes escoger omitir MOSI o MISO y utilizar el Pmod de solo-entrada o solo-salida.
+SPI - doble I/O y cuádruple I/O
+
+Ver: https://digilent.com/reference/pmod/pmodsf3/start
+
+uio[0] - CS\
+uio[1] - MOSI\
+uio[2] - MISO\
+uio[3] - SCK\
+uio[4] - NC\
+uio[5] - RST\
+uio[6] - WP\
+uio[7] - HLD
+
+**UART (control de flujo por hardware opcional)**
+
+El protocolo UART utiliza TXD y RXD, y opcionalmente CTS y RTS. Solo se usa una fila del conector Pmod, preferiblemente la fila superior:
+
+Fila superior:
+
+uio[0] - (CTS)\
+uio[1] - TXD\
+uio[2] - RXD\
+uio[3] - (RTS)
+
+Fila inferior:
+
+uio[4] - (CTS)\
+uio[5] - TXD\
+uio[6] - RXD\
+uio[7] - (RTS)
+
+Si tu diseño solo recibe o solo transmite, puedes escoger omitir TXD o RXD y luego utilizar los Pmod de solo-entrada o solo-salida.
+
+**I2C (interrupción y reset opcional)**
+
+El pinout para I2C usa SCL y SDA y opcionalmente INT y RESET para interrupciones y reset. Solo se usa una fila del conector Pmod, preferiblemente la fila superior:
+
+Fila superior:
+
+uio[0] - (INT)\
+uio[1] - (RESET)\
+uio[2] - SCL\
+uio[3] - SDA
+
+Fila inferior:
+
+uio[4] - (INT)\
+uio[5] - (RESET)\
+uio[6] - SCL\
+uio[7] - SDA

--- a/content/teaching/_index.es.md
+++ b/content/teaching/_index.es.md
@@ -1,0 +1,63 @@
+---
+title: "Recursos pedagógicos"
+date: 2023-03-10T10:12:12+01:00
+weight: 80
+---
+
+TinyTapeout es un proyecto educativo que facilita la enseñanza de diseño digital y la fabricación de estos diseños en chips reales.
+
+Nuestro modelo de precios facilita colocar varios diseños en un solo chip, el cual luego es compartido entre estudiantes.
+
+> Hola, soy el profesor de un curso de Introducción a Sistemas Digitales y acabo de encontrar esto, y solo digamos que **este curso ha cambiado totalmente nuestro plan de estudio de Ingeniería en Computadores**. Nos ha mostrado que realmente podemos hacer que estudiantes de primer año puedan diseñar ASICs, y después ser capaces de analizar rendimiento mientras hacen sus cursos de electrónica y aprenden de MOSFETs, así como sobre sus sistemas embebidos y arquitectura de computadores. *Russell Trafford, Rowan University*
+
+# Suscríbase a la lista de correo
+
+Para recibir más información especialmente para quienes estén usando Tiny Tapeout con propósitos educativos, suscríbase a nuestra lista de correo.
+
+{{< mailchimp-teacher >}}
+
+# Consejos para escuelas secundarias
+
+## Preparación
+
+* Mire el [video introductorio](https://youtu.be/f4w1QOpHzOo)
+* Complete algunos de los [cursos de diseño digital](../../es/digital_design/)
+* Cree un nuevo diseño o utilice uno de nuestros [proyectos personalizables](/tags/customisable/)
+* Cree los [archivos GDS necesarios para fabricación](https://tinytapeout.com/#get-your-submission-ready)
+* Eche un vistazo a las [preguntas frecuentes](../../es/faq)
+
+## Enseñanza
+
+* Los participantes van a necesitar una laptop e idealmente audífonos y un mouse.
+* Use las [presentaciones del seminario](https://docs.google.com/presentation/d/1NHFC3NHHFAzqK8HMGjxMHXJJ6r4j15dY86nk-boGDNM) para explicar cómo va a funcionar el programa.
+* Los estudiantes deberían completar la guía de diseño digital.
+* Los estudiantes con confianza pueden hacer sus propios diseños.
+* Los estudiantes que requieran más ayuda pueden personalizar algunos de los [proyectos personalizables](/tags/customisable/).
+
+## Envío
+
+* Envíe usted mismo los diseños de los participantes con una tarjeta de crédito o póngase en contacto con nosotros para obtener tokens prepagos.
+* Este programa es nuevo, y aún tenemos incertidumbres con respecto a cuánto tiempo demorarán las entregas de los diseños, pero es probable que demoren alrededor de 12 meses.
+* Mientras espera, puede usar [SiliWiz](/../../es/siliwiz) para enseñar a sus estudiantes cómo se utilizan los semiconductores para construir los componentes básicos digitales que se usaron en el seminario.
+
+# Consejos para universidades
+
+## Preparación
+
+* Mire el [video introductorio](https://youtu.be/f4w1QOpHzOo)
+* Revise las [notas acerca de HDL](/../../es/hdl/)
+* Pruebe el flujo de trabajo con un proyecto de FPGA sencillo
+* Cree los [archivos GDS necesarios para fabricación](https://tinytapeout.com/#get-your-submission-ready)
+* Eche un vistazo a las [preguntas frecuentes](../../es/faq)
+
+## Envío
+
+* Envíe usted mismo los diseños de los participantes con una tarjeta de crédito o póngase en contacto con nosotros para obtener tokens prepagos.
+* Este programa es nuevo, y aún tenemos incertidumbres con respecto a cuánto tiempo demorarán las entregas de los diseños, pero es probable que demoren alrededor de 12 meses.
+* Mientras espera, puede usar [SiliWiz](/../../es/siliwiz) para enseñar a sus estudiantes cómo se utilizan los semiconductores para construir los componentes básicos digitales que se usaron en el seminario.
+
+# Suscríbase a la lista de correo
+
+Para recibir más información especialmente para quienes estén usando Tiny Tapeout con propósitos educativos, suscríbase a nuestra lista de correo.
+
+{{< mailchimp-teacher >}}


### PR DESCRIPTION
- **first commit:** spanish translation of:
    - *specs/*
    - *specs/clock*
    - *specs/pcb*
    - *specs/pinouts*
- **second commit:** minor error in english page.