### PR TITLE
feat: support tex math dollar syntax in project documentation

### DIFF
--- a/functions/chips/[shuttle]/[project]/index.ts
+++ b/functions/chips/[shuttle]/[project]/index.ts
@@ -76,6 +76,12 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           `<meta property="og:image:width" content="1200" />`,
           `<meta property="og:image:height" content="630" />`,
           '<meta name="twitter:card" content="summary_large_image"/>',
+
+          // if this stylesheet is missing, then the equation text is duplicated on page
+          // see https://katex.org/docs/browser
+          `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.27/dist/katex.min.css" 
+          integrity="sha384-Pu5+C18nP5dwykLJOhd2U4Xen7rjScHN/qusop27hdd2drI+lL5KvX7YntvT8yew" crossorigin="anonymous">`,
+          `<link href="/css/katex.css" rel="stylesheet">`,
         ].join('\n'),
       )
       .replaceAll('__ttreplace_shuttle_id__', shuttle)

--- a/functions/components/ProjectPage.tsx
+++ b/functions/components/ProjectPage.tsx
@@ -35,6 +35,7 @@ export function ProjectPage({
       throwOnError: true,
       strict: true, // be faithful to LaTeX math
       trust: false, // prevent commands which cause adverse behaviour
+      maxSize: 80,
     },
   });
 

--- a/functions/components/ProjectPage.tsx
+++ b/functions/components/ProjectPage.tsx
@@ -3,6 +3,7 @@
 
 import MarkdownIt from 'markdown-it';
 import React from 'react';
+import katex from 'katex';
 import { IProjectFeedbackList, summarizeFeedback } from '../model/feedback.js';
 import { markdownHeadingLimiter, markdownImagePathTransformer } from '../model/project.js';
 import { getShuttlePdk, scanchainShuttles, type IShuttleIndexProject } from '../model/shuttle.js';
@@ -27,7 +28,15 @@ export function ProjectPage({
   feedback,
   shuttleMapSvg,
 }: IProjectPropProps) {
-  const md = MarkdownIt();
+  const md = MarkdownIt().use(require('markdown-it-texmath'), {
+    engine: katex,
+    // see https://katex.org/docs/options for all options
+    katexOptions: {
+      throwOnError: true,
+      strict: true, // be faithful to LaTeX math
+      trust: false, // prevent commands which cause adverse behaviour
+    },
+  });
 
   // Add base URL to image paths
   md.renderer.rules['image'] = markdownImagePathTransformer(shuttle, project.macro);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "dependencies": {
     "@cloudflare/pages-plugin-vercel-og": "^0.1.2",
+    "katex": "^0.16.27",
     "markdown-it": "^14.1.0",
+    "markdown-it-texmath": "^1.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/static/css/katex.css
+++ b/static/css/katex.css
@@ -1,0 +1,11 @@
+/* set font-size to match the rest of the content (https://katex.org/docs/font) */
+.katex {
+  font-size: 1em;
+}
+
+/* hide equation numbering - this isn't supported in the datasheet, so to avoid confusion i'll just hide it
+   there is no option to toggle it, see https://github.com/KaTeX/KaTeX/discussions/3180
+*/
+.eqn-num {
+  display: none !important;
+}


### PR DESCRIPTION
Ref https://github.com/TinyTapeout/tinytapeout-gf-0p2/pull/90

This PR adds support for rendering math using the tex dollar syntax (`$$..$$` and `$..$`) in the project documentation on the website. This brings it more in-line with the shuttle datasheet, as it uses the tex dollar syntax too.

Using the project above as an example with the new changes:
<img width="1475" height="790" alt="image" src="https://github.com/user-attachments/assets/b90fbc85-ea73-4aaa-bb00-d0228521b436" />


I had originally mentioned [markdown-it-dollarmath](https://github.com/executablebooks/markdown-it-dollarmath), but that package hasn't been updated for the node version being used, so I had to switch to `markdown-it-texmath`.

I've marked this as a draft PR for now since there's some points I want to address:
1. @urish mentioned that I should double check that malicious HTML can't be inserted, and I've tried to mitigate that with the `throwOnError`, `strict` and `trust` options for `katex` ([docs](https://katex.org/docs/options)), but I feel like that isn't sufficient - do you know of any resources for better testing?
2. Related to (1), would it be worthwhile to implement [DOMPurify](https://github.com/cure53/DOMPurify)?
3. Somewhat related to (1), but is there a better way of testing the website while modifying user content? I resorted to hosting my own index server and had to patch the address it fetched the details from...