### PR TITLE
feat: add config option to select template for workshops

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,7 @@ enableGitInfo = true
   defaultContentLanguage = 'en'
   disableLightbox = true
   workshopFeedbackLink = "https://docs.google.com/forms/d/e/1FAIpQLSeVc9YmYN5TYKsDpFGyPtZE6N3sstT2PcbTdee-bK8FMjQwEQ/viewform?usp=header"
+  workshopFoundry = "sky"
 
 [outputs]
   home = [ "HTML", "RSS", "JSON"]

--- a/content/guides/advanced-workshop/create-gds-from-vga-playground/_index.en.md
+++ b/content/guides/advanced-workshop/create-gds-from-vga-playground/_index.en.md
@@ -16,8 +16,7 @@ this, you'll have a GitHub repository containing your modified VGA design which 
 You'll need to create a repository using our template. It contains all the files and settings necessary to convert
 your design to the GDS we need for manufacture.
 
-<!--  - Visit [github.com/TinyTapeout/ttihp-verilog-template](https://github.com/TinyTapeout/ttihp-verilog-template). -->
-- Visit [github.com/TinyTapeout/ttsky-verilog-template](https://github.com/TinyTapeout/ttsky-verilog-template).
+- Visit {{< get-workshop-template-link >}}
 - Click "Use this template" and then "Create a new repository".
 
 {{< figure src="images/git-repo-template.png" title="Using the IHP template repository to create a new one" >}}

--- a/layouts/shortcodes/get-workshop-template-link.html
+++ b/layouts/shortcodes/get-workshop-template-link.html
@@ -1,0 +1,13 @@
+{{ with .Site.Params.workshopFoundry }}
+    {{ if eq . "sky" }}
+        <a href="https://www.github.com/TinyTapeout/ttsky-verilog-template">github.com/TinyTapeout/ttsky-verilog-template</a>
+    {{ else if eq . "ihp" }}
+        <a href="https://www.github.com/TinyTapeout/ttihp-verilog-template">github.com/TinyTapeout/ttihp-verilog-template</a>
+    {{ else if eq . "gf" }}
+        <a href="https://www.github.com/TinyTapeout/ttgf-verilog-template">github.com/TinyTapeout/ttgf-verilog-template</a>
+    {{ else }}
+        {{ errorf "params.workshopFoundry is set (%s), but is not one of ['sky', 'ihp', 'gf']" . }}
+    {{ end }}
+{{ else }}
+    {{ errorf "params.workshopFoundry in config is not set, no template url is available for workshop guide" }}
+{{ end }}


### PR DESCRIPTION
This commit adds a new parameter in `config.toml`  called `params.workshopFoundry`, and a new shortcode which references this parameter. When set to `sky`, `ihp` or `gf`, it will place the corresponding github repo URL wherever the shortcode (`get-workshop-template-link`) is used.

If it is unset or if it is an unknown value, then the build will fail.

The workshop guide at `guides/advanced-workshop/create-gds-from-vga-playground` has been updated to use this shortcode.

Known issue: Hugo places an extra whitespace after the URL, therefore the shortcode cannot be immediately followed by an punctuation because it would look weird. I've tried some methods to try and fix it, but they've not been successful :(

Closes #221