### PR TITLE
feat: adjust news banner position & social preview generator options

### DIFF
--- a/content/news/mini-mosbius/_index.en.md
+++ b/content/news/mini-mosbius/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/thumbnail.png
     alt: Circuit layout render of the Mini MOSBius
+    pos: top center
 ---
 
 MOSBius is a fantastic, practical tool for learning the fundamentals of analog microelectronics. Simulation is one thing,

--- a/content/news/news-launch/_index.en.md
+++ b/content/news/news-launch/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/render.png
     alt: A render of a chip. Wires in blue, and the background in chrome.
+    pos: 0% 5%
 ---
 
 Welcome to our new news section. We hope to fill this spot with plenty of new and exciting news about the world of open

--- a/content/news/tt-hackaday/_index.en.md
+++ b/content/news/tt-hackaday/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/image2.jpg
     alt: Supercon 2022 Matt Venn's Tiny Tapeout Brings Chip Design to the Masses
+    social_options: crop smart
 ---
 
 Tiny Tapeout made its first major conference appearance at Hackaday Supercon 2022, where Matt Venn took the stage to introduce the project to the hardware community.

--- a/content/news/tt02-silicon-bringup/_index.en.md
+++ b/content/news/tt02-silicon-bringup/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/live.jpg
     alt: Youtube Live
+    social_options: fit smart
 ---
 
 With the [TT02](/chips/tt02) chips finally back from the factory, Matt Venn hosted what we believe is the **world's first** live open-source silicon bring-up on [YouTube](https://www.youtube.com/live/MtnDSDFZuag), joined by Uri Shaked and Pat Deegan.

--- a/content/news/tt04-launch-event/_index.en.md
+++ b/content/news/tt04-launch-event/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/image.jpg
     alt: Matt & Uri
+    social_options: crop smart
 ---
 
 We hosted the [TT04](/chips/tt04/) launch event live on StreamYard, with Matt Venn joined by special guests Uri Shaked and Pat Deegan. 

--- a/content/news/tt04-opens/_index.en.md
+++ b/content/news/tt04-opens/_index.en.md
@@ -9,6 +9,7 @@ layout: single
 cover:
     image: images/tt04.jpg
     alt: TinyTapeout 
+    social_options: fit smart
 ---
 
 [TT04](/chips/tt04) is open for submissions!

--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -8,7 +8,7 @@
                 {{ $image_alt := .Params.cover.alt }}
                 {{ with .Resources.GetMatch .Params.cover.image }}
                     <div class="news-cover-image">
-                        <img loading="lazy" src="{{ .RelPermalink }}" alt="{{ .Params.cover.alt }}">
+                        <img loading="lazy" src="{{ .RelPermalink }}" alt="{{ $image_alt }}">
                     </div>
                 {{ end }}
             {{ end }}

--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -6,9 +6,10 @@
         <div class="news-entry">
             {{ if .Params.cover }}
                 {{ $image_alt := .Params.cover.alt }}
+                {{ $image_pos := .Params.cover.pos | default "center center" }}
                 {{ with .Resources.GetMatch .Params.cover.image }}
                     <div class="news-cover-image">
-                        <img loading="lazy" src="{{ .RelPermalink }}" alt="{{ $image_alt }}">
+                        <img loading="lazy" src="{{ .RelPermalink }}" alt="{{ $image_alt }}" style="object-position: {{ $image_pos }};">
                     </div>
                 {{ end }}
             {{ end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -42,9 +42,9 @@
 
 {{ if .Params.cover }}
   {{ $thumbnail_path := path.Join .Path "thumbnail.jpg" }}
-  {{ $social_options := "1280x720 crop center jpeg" }}
+  {{ $social_options := "1200x630 crop center jpeg" }}
   {{ if .Params.cover.social_options }}
-    {{ $social_options = printf "1280x720 %s jpeg" .Params.cover.social_options }}
+    {{ $social_options = printf "1200x630 %s jpeg" .Params.cover.social_options }}
   {{ end }}
   {{ with .Resources.GetMatch .Params.cover.image }}
     {{ $social_img := .Resize $social_options | resources.Copy $thumbnail_path }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -42,8 +42,12 @@
 
 {{ if .Params.cover }}
   {{ $thumbnail_path := path.Join .Path "thumbnail.jpg" }}
+  {{ $social_options := "1280x720 crop center jpeg" }}
+  {{ if .Params.cover.social_options }}
+    {{ $social_options = printf "1280x720 %s jpeg" .Params.cover.social_options }}
+  {{ end }}
   {{ with .Resources.GetMatch .Params.cover.image }}
-    {{ $social_img := .Resize "1280x720 cropped center jpeg" | resources.Copy $thumbnail_path }}
+    {{ $social_img := .Resize $social_options | resources.Copy $thumbnail_path }}
     {{/*  be warned of this bug: https://github.com/gohugoio/hugo/issues/10584  */}}
     {{ $social_img.Publish }}
     <meta property="og:image" content="{{ $social_img.Permalink }}">

--- a/static/css/news.css
+++ b/static/css/news.css
@@ -34,14 +34,25 @@ div.news-cover-image {
   max-height: 200px;
   max-width: 100vw;
   overflow: hidden;
+  position: relative;
 }
 
 .news-cover-image img {
   margin: 0 auto !important;
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover;
+  position: absolute;
 }
 
+/*  the theme always nests an image within an anchor tag, meaning we need to adjust the size of <a>
+    to allow for position: absolute to function properly, otherwise object-position doesn't work
+*/
 .news-cover-image a {
   pointer-events: none;
+  display: block;
+  height: 200px;
+  max-width: 100vw;
 }
 
 .news-container {


### PR DESCRIPTION
This PR adds the ability to control the news banner position and social preview generator options from the frontmatter of the news article. I've updated some articles to make use of it them. Also fixes the missing alt text from the news article image on the landing page.

Use the `cover.pos` key and pass in a value such as `top center` or `0% 30%`. This value is passed to [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-position) - the effect may not be fully visible on mobile devices because a larger portion of the image is showing.

Use the `cover.social_options` to adjust how the social media preview image is generated. I felt that this was necessary to add because some images (especially those with people in) don't look too good being squashed. For example:
<img width="354" height="273" alt="image" src="https://github.com/user-attachments/assets/939e1368-3485-41f9-80c1-4801ce27a33f" />

With the changes (using smart cropping, as provided by Hugo):
<img width="359" height="282" alt="image" src="https://github.com/user-attachments/assets/357490a8-1729-495d-aed0-33a3da85207d" />

This is all achieved using Hugo's `Resize` function, and there are plenty of options to control the behaviour of it - see the docs: https://gohugo.io/methods/resource/resize/
