### PR TITLE
hugo updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Contribution instructions:
 
 * fork this repository
 * *clone the forked repository recursively*
-* install hugo:
+  updated as needed: ` git submodule update --init --recursive`
+* install [hugo]("https://github.com/gohugoio/hugo) at least version  `0.112.4`, preferably `0.159` or newer:
     * linux: `snap install hugo`
     * other platforms: https://gohugo.io/getting-started/installing/
 * after cloning the repo, change to the new directory: cd tinytapeout_www

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://tinytapeout.com'
-languageCode = 'en-us'
+locale = 'en-US'
 title = 'Tiny Tapeout'
 theme = ["learn", "hugo-shortcode-gallery"]
 enableGitInfo = true
@@ -30,21 +30,21 @@ enableGitInfo = true
   [Languages.en]
     title = "Quicker, easier and cheaper to make your own chip!"
     weight = 1
-    languageName = "English"
+    label = "English"
 
   [Languages.es]
     title = "¡Hacer tu propio chip de forma más rápida, más fácil y más barata!"
     weight = 2
-    languageName = "Español"
+    label = "Espa\u00f1ol"
 
   [Languages.ua]
     title = "Документація українською"
     weight = 3
-    languageName = "Українська"
+    label = "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430"
 
   [Languages.it]
-    title = "Crea il tuo microchip in modo più veloce, più semplice ed economico!"
+    title = "Crea il tuo microchip in modo piÃ¹ veloce, piÃ¹ semplice ed economico!"
     weight = 4
-    languageName = "Italiano"
+    label = "Italiano"
 
 #disableLanguages = ['es', 'it']

--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,7 @@ enableGitInfo = true
     label = "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430"
 
   [Languages.it]
-    title = "Crea il tuo microchip in modo piÃ¹ veloce, piÃ¹ semplice ed economico!"
+    title = "Crea il tuo microchip in modo più veloce, più semplice ed economico!"
     weight = 4
     label = "Italiano"
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -58,22 +58,15 @@
             <i class="fas fa-language fa-fw"></i>
           <div class="select-style">
             <select id="select-language" onchange="location = this.value;">
-          {{ $siteLanguages := .Site.Languages}}
-          {{ $pageLang := .Page.Lang}}
-          {{ range .Page.AllTranslations }}
-              {{ $translation := .}}
-              {{ range $siteLanguages }}
-                  {{ if eq $translation.Lang .Lang }}
-                    {{ $selected := false }}
-                    {{ if eq $pageLang .Lang}}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>{{ .LanguageName }}</option>
-                    {{ else }}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}</option>
-                    {{ end }}
-                  {{ end }}
+              {{ $pageLang := .Page.Language.Name }}
+              {{ range .Page.AllTranslations }}
+                {{ if eq $pageLang .Language.Name }}
+                  <option id="{{ .Language.Name }}" value="{{ .Permalink }}" selected>{{ .Language.Label }}</option>
+                {{ else }}
+                  <option id="{{ .Language.Name }}" value="{{ .Permalink }}">{{ .Language.Label }}</option>
+                {{ end }}
               {{ end }}
-          {{ end }}
-        </select>
+            </select>
         <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
           width="255px" height="255px" viewBox="0 0 255 255" style="enable-background:new 0 0 255 255;" xml:space="preserve">
           <g>

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -17,7 +17,7 @@
   <meta property="og:description" content="{{ . }}">
 {{- end }}
 
-{{- with or .Params.locale site.Language.LanguageCode }}
+{{- with or .Params.locale site.Language.Locale }}
   <meta property="og:locale" content="{{ replace . `-` `_` }}">
 {{- end }}
 


### PR DESCRIPTION
Without this update, the following warnings are observed with the latest `0.163.3` release of hugo.

```
WARN  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use locale instead.
WARN  deprecated: project config key languages.ua.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.ua.label instead.
WARN  deprecated: project config key languages.it.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.it.label instead.
WARN  deprecated: project config key languages.en.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.en.label instead.
WARN  deprecated: project config key languages.es.languageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use languages.es.label instead.
...
WARN  deprecated: .Language.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Language.Locale instead.
WARN  deprecated: .Site.Languages was deprecated in Hugo v0.156.0 and will be removed in a future release. See https://discourse.gohugo.io/t/56732.
WARN  deprecated: .Language.LanguageName was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Language.Label instead.
```