### PR TITLE
feat(layouts/news): add newsletter signup to the end of each article

### DIFF
--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -25,6 +25,33 @@
 <div class="news-container">
     <div class="news-content">
         {{ .Content }}
+        <hr>
+        <p>If you enjoyed this article, please consider signing up to our newsletter below.</p>
+        <!-- Begin Mailchimp Signup Form -- this is copied from layouts/shortcodes/mailchimp.html -->
+        <div id="mc_embed_signup">
+            <form action="https://zerotoasiccourse.us7.list-manage.com/subscribe/post?u=5d5a474f6c30e153ec17de7b5&amp;id=eada08e6e4&amp;f_id=00d33de5f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+                <div id="mc_embed_signup_scroll">
+                    <div class="mc-field-group">
+                        <label for="mce-EMAIL">Email Address</label>
+                        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" required>
+                        <span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
+                    </div>
+                    <div hidden="true"><input type="hidden" name="tags" value="6821095"></div>
+                    <div id="mce-responses" class="clear foot">
+                        <div class="response" id="mce-error-response" style="display:none"></div>
+                        <div class="response" id="mce-success-response" style="display:none"></div>
+                    </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_5d5a474f6c30e153ec17de7b5_eada08e6e4" tabindex="-1" value=""></div>
+                    <div class="optionalParent">
+                        <div class="clear foot">
+                            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='MMERGE3';ftypes[3]='number';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+    <!--End mc_embed_signup-->
     </div>
     <div class="news-footer">
         <hr>


### PR DESCRIPTION
This PR updates the news article layout to include a newsletter signup form at the end of the content. 

The implementation is copied straight from `/layouts/shortcodes/mailchimp.html`, which unfortunately does result in some duplication as you can't call shortcodes from layouts. Remember to update the mailchimp URL in both spots if it ever changes.