### PR TITLE
No edits during simulation

### DIFF
--- a/content/guides/workshop/simulate-a-gate/_index.md
+++ b/content/guides/workshop/simulate-a-gate/_index.md
@@ -91,7 +91,8 @@ After you've chosen a component, it gets added to your schematic. Now let's wire
 * If you need to join wires together, add a **junction** component from the *+* menu.
 * You can drag components about by left-click-dragging them.
 * You can copy and paste a component or groups of components with control+c and control+v.
-* Undo and redo with control+z and control+y
+* Undo and redo with control+z and control+y.
+* Wiring changes are disabled while the simulation is running.
 
 For more Wokwi tips, check the [FAQ](https://tinytapeout.com/faq/#how-do-i-do-x-y-z-with-wokwi).
 


### PR DESCRIPTION
Adds a wiring tip that edits cannot be made while the simulation is running here:

https://tinytapeout.com/guides/workshop/simulate-a-gate/

It might be good if the simulation had some sort of visual alert when this is attempted.