### PR TITLE
feat: filter news articles by tag & year

### DIFF
--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -1,9 +1,32 @@
+<script src="/scripts/news-filter.js"></script>
 {{ partial "header.html" . }}
+
+{{ $tags := slice }}
+{{ range .Pages }}
+    {{ if .Params.tags }}
+        {{ $tags = $tags | append .Params.tags }}
+    {{ end }}
+{{ end }}
+
+{{ $tags = $tags | uniq }}
+
+{{ if $tags }}
+  <div class="news-tag-filters">
+    <button class="tag-filter btn button" data-filter="all">All</button>
+  {{ range $tags}}
+    <button class="tag-filter btn button-secondary" data-filter="{{ . }}">{{strings.FirstUpper .}}</button>
+  {{ end }}
+  </div>
+{{ end }}
 
 <div id="news-entries">
 {{ range .Page.Sections.ByDate.Reverse }}
     <a href="{{.RelPermalink}}">
-        <div class="news-entry">
+        {{ if .Params.tags }}
+            <div class="news-entry" data-filter="{{ delimit .Params.tags ' '}}">
+        {{ else }}
+            <div class="news-entry">
+        {{ end }}
             {{ if .Params.cover }}
                 {{ $image_alt := .Params.cover.alt }}
                 {{ $image_pos := .Params.cover.pos | default "center center" }}

--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -14,7 +14,7 @@
   <div class="news-tag-filters">
     <button class="tag-filter btn button" data-filter="all">All</button>
   {{ range $tags}}
-    <button class="tag-filter btn button-secondary" data-filter="{{ . }}">{{strings.FirstUpper .}}</button>
+    <button class="tag-filter btn button-secondary" data-filter='{{ replace . " " "-" }}'>{{strings.FirstUpper .}}</button>
   {{ end }}
   </div>
 {{ end }}
@@ -23,7 +23,11 @@
 {{ range .Page.Sections.ByDate.Reverse }}
     <a href="{{.RelPermalink}}">
         {{ if .Params.tags }}
-            <div class="news-entry" data-filter="{{ delimit .Params.tags ' '}}">
+            {{ $page_tags := slice}}
+            {{ range .Params.tags }}
+                {{ $page_tags = $page_tags | append (replace . " " "-") }}
+            {{ end }}
+            <div class="news-entry" data-filter='{{ delimit $page_tags " "}}'>
         {{ else }}
             <div class="news-entry">
         {{ end }}

--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -2,17 +2,31 @@
 {{ partial "header.html" . }}
 
 {{ $tags := slice }}
+{{ $years := slice }}
 {{ range .Pages }}
     {{ if .Params.tags }}
         {{ $tags = $tags | append .Params.tags }}
     {{ end }}
+    {{ if .Date }}
+        {{ $years = $years | append (.Date.Format "2006") }}
+    {{ end }}
 {{ end }}
 
 {{ $tags = $tags | uniq }}
+{{ $years = $years | uniq }}
+
+{{ if $years }}
+  <div class="news-tag-filters">
+    <button class="date-filter btn button" data-date="all-dates">All dates</button>
+  {{ range $years}}
+    <button class="date-filter btn button-secondary" data-date='{{ . }}'>{{.}}</button>
+  {{ end }}
+  </div>
+{{ end }}
 
 {{ if $tags }}
   <div class="news-tag-filters">
-    <button class="tag-filter btn button" data-filter="all">All</button>
+    <button class="tag-filter btn button" data-filter="all-tags">All tags</button>
   {{ range $tags}}
     <button class="tag-filter btn button-secondary" data-filter='{{ replace . " " "-" }}'>{{strings.FirstUpper .}}</button>
   {{ end }}
@@ -27,7 +41,7 @@
             {{ range .Params.tags }}
                 {{ $page_tags = $page_tags | append (replace . " " "-") }}
             {{ end }}
-            <div class="news-entry" data-filter='{{ delimit $page_tags " "}}'>
+            <div class="news-entry" data-filter='{{ delimit $page_tags " "}}' data-date='{{.Date.Format "2006"}}'>
         {{ else }}
             <div class="news-entry">
         {{ end }}

--- a/static/css/news.css
+++ b/static/css/news.css
@@ -65,7 +65,6 @@ div.news-cover-image {
 div#news-entries {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 }
 
 #news-entries a {
@@ -74,7 +73,6 @@ div#news-entries {
 }
 
 #news-entries > a:hover {
-  background-color: #f5f5f5;
   transform: scale(1.01);
 }
 
@@ -94,6 +92,11 @@ div#news-entries {
 div.news-entry {
   border: solid 1px var(--MENU-SECTION-ACTIVE-CATEGORY-color);
   padding: 10px 10px 0px 10px;
+  margin-bottom: 1rem;
+}
+
+div.news-entry:hover {
+  background-color: #f5f5f5;
 }
 
 .news-entry h2 {
@@ -108,4 +111,12 @@ div.news-entry {
 
 .news-entry .news-metadata {
   font-size: 0.9rem;
+}
+
+.news-tag-filters {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 10px;
+  margin: 20px 0px;
+  justify-content: center;
 }

--- a/static/css/theme-tinytapeout.css
+++ b/static/css/theme-tinytapeout.css
@@ -121,3 +121,20 @@ a:hover {
 #sidebar hr {
   border-color: var(--MENU-SECTION-HR-color);
 }
+
+/* Ensure that text within the button is rendered white - this was getting stuck on black when doing news tags */
+.button:focus {
+  color: #fff !important;
+}
+
+/* Recolour default secondary buttons */
+.button-secondary {
+  background: #d6d6d6;
+  color: #000;
+  box-shadow: 0 3px 0 #9c6fb6;
+}
+
+.button-secondary:hover {
+  background: #bf9ad4;
+  box-shadow: 0 3px 0 #bf9ad4;
+}

--- a/static/scripts/news-filter.js
+++ b/static/scripts/news-filter.js
@@ -1,30 +1,61 @@
 document.addEventListener('DOMContentLoaded', function () {
   const tagFilterButtons = document.querySelectorAll('.tag-filter');
-  const newsEntries = document.querySelectorAll('.news-entry');
+  const dateFilterButtons = document.querySelectorAll('.date-filter');
+  const allFilterButtons = document.querySelectorAll('.tag-filter, .date-filter');
 
-  tagFilterButtons.forEach((button) => {
+  // convert to array for filtering later
+  const newsEntries = Array.from(document.querySelectorAll('.news-entry'));
+
+  // default filter settings
+  var filterValue = 'all-tags';
+  var dateValue = 'all-dates';
+
+  allFilterButtons.forEach((button) => {
     button.addEventListener('click', function () {
-      const filterValue = this.dataset.filter;
+      // determine which filter was clicked
+      const isTagFilter = this.dataset.filter != null;
+      const isDateFilter = this.dataset.date != null;
 
-      // when a button is clicked, style every button as a secondary button
-      tagFilterButtons.forEach((btn) => {
-        btn.classList.remove('button');
-        btn.classList.add('button-secondary');
+      // update tag filter button styling
+      if (isTagFilter) {
+        tagFilterButtons.forEach((btn) => {
+          btn.classList.remove('button');
+          btn.classList.add('button-secondary');
+        });
+        this.classList.remove('button-secondary');
+        this.classList.add('button');
+        filterValue = this.dataset.filter;
+      }
+
+      // update date filter button styling
+      if (isDateFilter) {
+        dateFilterButtons.forEach((btn) => {
+          btn.classList.remove('button');
+          btn.classList.add('button-secondary');
+        });
+        this.classList.remove('button-secondary');
+        this.classList.add('button');
+        dateValue = this.dataset.date;
+      }
+
+      // if filter is unset, treat it the same as 'all-{dates, tags}' - return untouched array
+      const dateFilteredEntries =
+        dateValue == 'all-dates'
+          ? newsEntries
+          : newsEntries.filter((entry) => entry.dataset.date.includes(dateValue));
+      const tagFilteredEntries =
+        filterValue == 'all-tags'
+          ? dateFilteredEntries
+          : dateFilteredEntries.filter((entry) => entry.dataset.filter.includes(filterValue));
+
+      // hide all articles
+      newsEntries.forEach((entry) => {
+        entry.style.display = 'none';
       });
 
-      // then on the button just clicked, add the primary button styling
-      this.classList.remove('button-secondary');
-      this.classList.add('button');
-
-      // filter the news entries given the clicked button
-      newsEntries.forEach((entry) => {
-        if (filterValue === 'all') {
-          entry.style.display = 'block';
-        } else if (entry.dataset.filter.includes(filterValue)) {
-          entry.style.display = 'block';
-        } else {
-          entry.style.display = 'none';
-        }
+      // only show filtered articles
+      tagFilteredEntries.forEach((entry) => {
+        entry.style.display = 'block';
       });
     });
   });

--- a/static/scripts/news-filter.js
+++ b/static/scripts/news-filter.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const tagFilterButtons = document.querySelectorAll('.tag-filter');
+  const newsEntries = document.querySelectorAll('.news-entry');
+
+  tagFilterButtons.forEach((button) => {
+    button.addEventListener('click', function () {
+      const filterValue = this.dataset.filter;
+
+      // when a button is clicked, style every button as a secondary button
+      tagFilterButtons.forEach((btn) => {
+        btn.classList.remove('button');
+        btn.classList.add('button-secondary');
+      });
+
+      // then on the button just clicked, add the primary button styling
+      this.classList.remove('button-secondary');
+      this.classList.add('button');
+
+      // filter the news entries given the clicked button
+      newsEntries.forEach((entry) => {
+        if (filterValue === 'all') {
+          entry.style.display = 'block';
+        } else if (entry.dataset.filter.includes(filterValue)) {
+          entry.style.display = 'block';
+        } else {
+          entry.style.display = 'none';
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the ability to filter news articles by their given tags and published year. The `/news` page has been updated to now include a set of buttons:

<img width="702" height="216" alt="image" src="https://github.com/user-attachments/assets/8ac7724d-1257-4dfe-a6c8-3ca920d291f6" />

A reader can click on these buttons to select their desired topic and year. These buttons are automatically generated by looking at _only_ the news articles - other pages which make use of tags will not appear on this page. Currently only one year and one topic can be selected.

Filtering is handled by javascript and makes use of the [HTML `data-*` attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/data-*).