### PR TITLE
fix(teaching): fix styling for pricing table

### DIFF
--- a/layouts/shortcodes/pricing-table.html
+++ b/layouts/shortcodes/pricing-table.html
@@ -15,7 +15,7 @@
     <a href="/contact" target="_blank" rel="no-follow" class="button">
       Contact us
     </a>
-
+    <br>
     <a href="{{ .link }}" target="_blank" rel="no-follow">
       Customize plan
     </a>

--- a/static/css/pricing-table.css
+++ b/static/css/pricing-table.css
@@ -1,28 +1,21 @@
 .pricing-table {
-  display: flex;
-  justify-content: flex-start;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
 }
 
 .pricing-table .pricing-plan {
-  max-width: 250px;
   border: 1px solid #ccc;
   color: inherit;
   padding: 20px;
   border-radius: 10px;
-  width: 30%;
   text-align: center;
-  margin-right: 24px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
   .pricing-table {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-
-  .pricing-table .pricing-plan {
-    margin-right: 12px;
-    margin-bottom: 12px;
+    gap: 12px;
   }
 }
 


### PR DESCRIPTION
The pricing table used in `/teaching` would resize weirdly and end up being malformed on smaller screens. Now it will dynamically resize depending on available space & total number of plans.

Fixes #213