### PR TITLE
fix: incorrectly labeled analog pins for latest shuttles

### DIFF
--- a/functions/components/AnalogPinout.tsx
+++ b/functions/components/AnalogPinout.tsx
@@ -15,7 +15,7 @@ export function AnalogPinout({
 
   // shuttles which do not come with the ETR demo board
   // using this as a way of differenciating which pinout should be displayed
-  const nonETRShuttles = ['tt01', 'tt02', 'tt03', 'tt04', 'tt05', 'tt06', 'tt07', 'tt08'];
+  const nonETRShuttles = ['tt06', 'tt07', 'tt08'];
 
   const letterLabels = ['C', 'D', 'F', 'G', 'J', 'K', 'X', 'W', 'U', 'T', 'R', 'Q'];
 

--- a/functions/components/AnalogPinout.tsx
+++ b/functions/components/AnalogPinout.tsx
@@ -4,11 +4,27 @@
 import React from 'react';
 import { IShuttleIndexProject } from '../model/shuttle.js';
 
-export function AnalogPinout({ project }: { project: IShuttleIndexProject }) {
+export function AnalogPinout({
+  shuttle,
+  project,
+}: {
+  shuttle: string;
+  project: IShuttleIndexProject;
+}) {
   const rows: React.ReactNode[] = [];
 
+  // shuttles which do not come with the ETR demo board
+  // using this as a way of differenciating which pinout should be displayed
+  const nonETRShuttles = ['tt01', 'tt02', 'tt03', 'tt04', 'tt05', 'tt06', 'tt07', 'tt08'];
+
+  const letterLabels = ['C', 'D', 'F', 'G', 'J', 'K', 'X', 'W', 'U', 'T', 'R', 'Q'];
+
   const breakoutPin = (analog: number) => {
-    return analog < 6 ? 'A' + analog : 'B' + (analog - 6);
+    if (shuttle in nonETRShuttles) {
+      return analog < 6 ? 'A' + analog : 'B' + (analog - 6);
+    } else {
+      return letterLabels[analog] ?? '';
+    }
   };
 
   for (const [ua, analog] of project.analog_pins.entries()) {

--- a/functions/components/ProjectPage.tsx
+++ b/functions/components/ProjectPage.tsx
@@ -115,7 +115,7 @@ export function ProjectPage({
       {hasAnalogPins && (
         <>
           <h3>Analog pins</h3>
-          <AnalogPinout project={project} />
+          <AnalogPinout shuttle={shuttle} project={project} />
         </>
       )}
 


### PR DESCRIPTION
The website would use the old style analog pinout notation even for boards which came with the ETR demoboard. This commit attempts to fix that by simply looking at which shuttle the project is a part of and deciding which pinout style to use.

It makes an assumption based the contents of `nonETRShuttles`, but it would be good to have a more concrete source of information.