### PR TITLE
feat(news): add dynamic social preview image

### DIFF
--- a/content/news/_index.en.md
+++ b/content/news/_index.en.md
@@ -5,4 +5,6 @@ weight: 5
 type: news
 layout: landing
 hideChildrenFromMenu: true
+images:
+    - /news/social-preview
 ---

--- a/functions/news/social-preview.tsx
+++ b/functions/news/social-preview.tsx
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026, Tiny Tapeout LTD
+// Author: Kristaps Jurkans
+
+import { ImageResponse } from '@cloudflare/pages-plugin-vercel-og/api';
+import React from 'react';
+import { isSkipCache } from '../utils/cache.js';
+
+const cache = caches.default;
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const cached = await cache.match(context.request);
+  if (cached && !isSkipCache(context)) {
+    return cached;
+  }
+
+  // see https://github.com/TinyTapeout/tt-datasheet-artwork/tree/main/artwork
+  // future artwork additions aren't guaranteed to have correct dimensions, so we'll just weed out them now
+  const availablePOCAImages = [
+    '01-A',
+    '01-B',
+    '01-C',
+    '01-D',
+    '01-E',
+    '01-F',
+    '01-G',
+    '01-H',
+    '01-I',
+  ];
+
+  // select a new image every month
+  const currentMonth = new Date().getMonth();
+  const selectedImage = availablePOCAImages[currentMonth % availablePOCAImages.length];
+
+  return new ImageResponse(
+    (
+      <div style={{ display: 'flex', width: '100%', height: '100%', justifyContent: 'center' }}>
+        <img
+          src={`https://raw.githubusercontent.com/TinyTapeout/tt-datasheet-artwork/refs/heads/main/artwork/TT-POCA-${selectedImage}.jpg`}
+          style={{
+            width: '100vw',
+            objectFit: 'contain',
+            transform: 'translate(0, -100px)',
+          }}
+        />
+      </div>
+    ),
+  );
+};

--- a/layouts/news/landing.html
+++ b/layouts/news/landing.html
@@ -1,4 +1,6 @@
 <script src="/scripts/news-filter.js"></script>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content='{{ absURL "/news/social-preview" }}'>
 {{ partial "header.html" . }}
 
 {{ $tags := slice }}


### PR DESCRIPTION
This commit adds a dynamically selected social preview image every month for the news landing page.

Images are selected from a predefined list of available TT-POCA images -- this is intended since these are fetched from the tt-datasheet-artwork repo and aren't guaranteed to be in the correct format.

These images are available from the `/news/social-preview` URL, similar to how it's done for the individual projects.