### PR TITLE
fix: failing link check job

### DIFF
--- a/content/competitions/demoscene-ttsky26a-announce/_index.en.md
+++ b/content/competitions/demoscene-ttsky26a-announce/_index.en.md
@@ -8,7 +8,7 @@ weight: 1
 
 {{%notice note%}}
 This competition is now closed! 
-Check out the entries on our [TTSKY26a Demoscene Entrants page](../demoscene-ttsky26a-entrants/).
+Check out the entries on our [TTSKY26a Demoscene Entries page](../demoscene-ttsky26a-entries/).
 {{%/notice%}}
 
 ## Demoscene competition!

--- a/lychee.toml
+++ b/lychee.toml
@@ -6,7 +6,8 @@ format = "markdown"
 accept = [
     200,
     429,
-    403
+    403,
+    202     # ieee.org returns this
 ]
 
 exclude = [
@@ -18,6 +19,7 @@ exclude = [
     "efabless-faq",
 
     # ignore certain websites
-    '^https://(www\.)?linkedin\.com',   # returns html code 999
+    '^https://(www\.)?(.+\.)?linkedin\.com',   # returns html code 999
     '^https://(www\.)?nyu\.edu',        # returns 405
+    '^https://(www\.)?efabless\.com',   # dead
 ]


### PR DESCRIPTION
This PR fixes a link and updates the config to ignore some additional URLs and status codes. Opening it as a draft at the moment to see whether the link check job behaves differently between github actions and locally.